### PR TITLE
Update base node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:12.19.1@sha256:31eebb77c7e3878c45419a69e5e7dddd376d685e064279e024e488076d97c7e4
+FROM node:lts-alpine3.20@sha256:cf5e7b223dea2efc6a73c55c6655b740576fe9c2596927a53533feded0fb5f5f
 
 ADD package.json package-lock.json /
 RUN npm ci --production


### PR DESCRIPTION
Before fix: https://github.com/step-security/workflow-playground/actions/runs/10053458209/job/27786269253#step:3:80

After fix: https://github.com/step-security/workflow-playground/actions/runs/10053757466/job/27787101661


node:lts-alpine3.20 is using `ENV NODE_VERSION=20.15.1` [checkout](https://hub.docker.com/layers/library/node/lts-alpine3.20/images/sha256-c1f4f4e7afa4f73df11ad95392ff316a4af82df0cb5ca114de1fe7c4dc4dcd20?context=explore)