### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 StepSecurity
+Copyright (c) 2026 StepSecurity
 Copyright (c) 2018 Nicolas Coutin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # 🚀 Discord for GitHub Actions
 
 Sends a Discord notification message. Simple as that.

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -70,19 +70,48 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
 // curl -X POST -H "Content-Type: application/json" --data "$(cat $GITHUB_EVENT_PATH)" $DISCORD_WEBHOOK/github
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "Ilshidur/action-discord";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  console.info("");
+  console.info("\u001b[1;36mStepSecurity Maintained Action\u001b[0m");
+  console.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    console.info("\u001b[32m\u2713 Free for public repositories\u001b[0m");
+  console.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`);
+  console.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, { timeout: 3000 });
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
       console.error(
-        "Subscription is not valid. Reach out to support@stepsecurity.io"
+        `\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`,
+      );
+      console.error(
+        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`,
       );
       process.exit(1);
-    } else {
-      console.info("Timeout or API not reachable. Continuing to next step.");
     }
+    console.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Updated LICENSE year to 2026

## Changes by type
- **Docker actions**: replaced entrypoint.js subscription validation function with new pattern that skips API check for public repos

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top

Auto-generated by StepSecurity update-propagator. Task ID: 20260409T074908Z